### PR TITLE
Adds a git alias for quickly merging a branch

### DIFF
--- a/gitconfig.local
+++ b/gitconfig.local
@@ -6,7 +6,10 @@
   d  = diff
   ds = diff --staged
   s = status -s
+  ca = commit --amend
   fuckit = !sh -c 'git add --all && git reset --hard'
+  branch-name = "!git rev-parse --abbrev-ref HEAD"
+  shipit = "!f() { local BRANCH=$(git branch-name) && git co master && git merge $BRANCH && git push && git push origin :$BRANCH && git db $BRANCH; }; f"
 
 [pretty]
   colored = format:%Cred%h%Creset %s %Cgreen(%cr) %C(bold blue)%an%Creset


### PR DESCRIPTION
Why:

I run the same set of commands whenever I want to merge a branch into
master and it's getting repetitive.

This PR:

Adds a shipit alias that will checkout master, merge the branch I was
on, push and delete remote and local copies of the branch.

Also brings back the commit ammend alias.
