### PR TITLE
Remove tmuxinator

### DIFF
--- a/zshrc.local
+++ b/zshrc.local
@@ -1,5 +1,3 @@
-source /Users/matthewsumner/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/tmuxinator-0.6.8/completion/tmuxinator.zsh
-
 # vim as editor
 export EDITOR=/usr/local/bin/vim
 


### PR DESCRIPTION
Why:

I've stopped using tmuxinator and much prefer using the `tat` alias.

This PR:

Removes a line to setup tmuxinator.
