### PR TITLE
Add github colourscheme

### DIFF
--- a/vimrc.local
+++ b/vimrc.local
@@ -69,3 +69,8 @@ set nowrap
 
 " remove all comments
 nmap <leader>c :%s/^\s*#.*$//g<CR>:%s/\(\n\)\n\+/\1/g<CR>:nohl<CR>gg
+
+" Color scheme
+colorscheme github
+highlight NonText guibg=#060606
+highlight Folded  guibg=#0A0A0A guifg=#9090D0


### PR DESCRIPTION
Why:

This used to be added by the thoughtbot dotfiles but was removed. See
https://github.com/thoughtbot/dotfiles/pull/359

This PR:

Adds github colorscheme for pretty colours!
